### PR TITLE
add print_tensor example

### DIFF
--- a/api_examples/paddle/fluid/pybind/print_tensor.py
+++ b/api_examples/paddle/fluid/pybind/print_tensor.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# api: paddle.fluid
+# env: local
+# device: cpu
+# text：print-tensor
+
+import paddle.fluid as fluid
+import numpy as np
+np.random.seed(9000)
+
+fluid.default_main_program().random_seed = 9000
+fluid.default_startup_program().random_seed = 9000
+def gen_data():
+    return {"x": np.random.random(size=(32, 32)).astype('float32'),
+            "y": np.random.randint(2, size=(32, 1)).astype('int64')}
+def mlp(input_x, input_y, hid_dim=128, label_dim=2):
+    fc_1 = fluid.layers.fc(input=input_x, size=hid_dim)
+    prediction = fluid.layers.fc(input=[fc_1], size=label_dim, act='softmax')
+    cost = fluid.layers.cross_entropy(input=prediction, label=input_y)
+    sum_cost = fluid.layers.reduce_mean(cost)
+    return sum_cost, fc_1, prediction
+
+input_x = fluid.layers.data(name="x", shape=[32], dtype='float32')
+input_y = fluid.layers.data(name="y", shape=[1], dtype='int64')
+cost, fc_1, pred = mlp(input_x, input_y)
+
+print("Finished FF")
+
+sgd = fluid.optimizer.Adam(learning_rate=0.01)
+sgd.minimize(cost)
+
+print("Finished optimize")
+place = fluid.CPUPlace()
+exe = fluid.Executor(place)
+exe.run(fluid.default_startup_program())
+step = 10
+
+with open("main_program.txt", 'w') as f:
+    f.write(str(fluid.default_main_program()))
+
+scope = fluid.global_scope()
+
+for i in range(step):
+    cost_val = exe.run(feed=gen_data(),
+                       program=fluid.default_main_program(),
+                       fetch_list=[cost.name])
+    print("step: %d, fc_0.w_0: %s" % (i, scope.var("fc_0.w_0").get_tensor().__array__()))

--- a/api_examples/paddle/fluid/pybind/print_tensor.py
+++ b/api_examples/paddle/fluid/pybind/print_tensor.py
@@ -15,7 +15,7 @@
 # api: paddle.fluid
 # env: local
 # device: cpu
-# text：print-tensor
+# text: print-tensor
 
 import paddle.fluid as fluid
 import numpy as np


### PR DESCRIPTION
“如何获取tensor的值”是常见的用户问题，这个example提供python端打印var的方法。
期望输出：

```shell
Finished FF
Finished optimize
step: 0, fc_0.w_0: [[-0.10529901 -0.07054191 -0.13647291 ... -0.10602473 -0.07899033
   0.15065548]
 [-0.04140715 -0.01182835  0.16131984 ... -0.07984839  0.12133842
   0.15614812]
 [ 0.16184261  0.01715499 -0.09326355 ...  0.10960961  0.17152914
  -0.02638819]
 ...
 [ 0.05344178  0.19962896  0.17339653 ... -0.12717575 -0.14681083
  -0.16763136]
 [ 0.07024567 -0.0378227  -0.14555416 ... -0.08571725 -0.08764564
  -0.14416358]
 [ 0.06530999 -0.10522798 -0.17464371 ... -0.05483579 -0.11235257
   0.10698551]]
step: 1, fc_0.w_0: [[-0.11046122 -0.07491808 -0.1330026  ... -0.10606746 -0.07532178
   0.14474227]
 [-0.04575856 -0.01516406  0.16354485 ... -0.08130027  0.12380067
   0.15079008]
 [ 0.15696704  0.0131518  -0.09024835 ...  0.10900916  0.17475878
  -0.03210694]
 ...
 [ 0.04812807  0.19505358  0.17711368 ... -0.12689237 -0.14290507
  -0.17364672]
 [ 0.0644531  -0.04303571 -0.14103071 ... -0.08423778 -0.08296889
  -0.15049967]
 [ 0.06018575 -0.1095545  -0.17123453 ... -0.0549566  -0.10874285
   0.101098  ]]
...
```

注意，只有在exe.run(fluid.default_startup_program())之后，参数才有值，才可以使用`print(scope.var("fc_0.w_0").get_tensor().__array__())`打印。